### PR TITLE
Fix link on about page

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -2,7 +2,11 @@
 title: "About"
 ---
 
-Deis Labs is a shoutout to Deis, the organization where many of started our journey into Kubernetes and Open Source - creating and nuturing the Helm project and working to simplify the tooling around Container Native development and operations.
+Deis Labs is a shoutout to Deis, the organization where many of started our
+journey into Kubernetes and Open Source - creating and nuturing the Helm project
+and working to simplify the tooling around Container Native development and
+operations.
 
 
-For more info see our [Introductionary Blog Post](posts/hello-world/), or follow [@deislabs](https://twitter.com/deislabs)
+For more info see our [Introductionary Blog Post](/posts/hello-world/), or
+follow [@deislabs](https://twitter.com/deislabs)


### PR DESCRIPTION
The link was relative instead of absolute, so it 404'd. While I was in there, I formatted the page so that it's easier to review in GH (line endings).