### PR TITLE
Fix twitter card URL

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,6 +7,8 @@ disableHugoGeneratorInject = true
 
 [params]
 
+  image = "images/twitter-card.png"
+  
   [params.font]
   name = "Nunito Sans"
   sizes = [

--- a/themes/fresh/layouts/partials/meta.html
+++ b/themes/fresh/layouts/partials/meta.html
@@ -7,8 +7,8 @@
 
 <meta name="twitter:card" content="summary_large_image">
 {{ if .Params.Image }}
-  <meta name="twitter:image" content="{{ .Site.BaseURL }}/{{ .Params.Image }}">
+  <meta name="twitter:image" content="{{ .Params.Image | absURL }}">
   {{ else }}
-  <meta name="twitter:image" content="{{ .Site.BaseURL }}/images/twitter-card.png">
+  <meta name="twitter:image" content="{{ .Site.Params.Image | absURL }}">
 {{ end }}
 


### PR DESCRIPTION
Use `absURL` function instead of manually concatenating with `Site.BaseURL` so that we don't need to manage the optional trailing slash depending on if we are in a deploy preview (no slash) or not
(slash).

We've been playing whack a mole with this problem and I think this is the recommended best practice for dealing with the inconsistent slash going forward.