### PR TITLE
ORAS is now a CNCF sandbox project

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -93,12 +93,6 @@ disableHugoGeneratorInject = true
     url = "https://krustlet.dev"
 
     [[params.section1.tiles]]
-    title = "ORAS"
-    icon = "oras"
-    text = "OCI (Open Container Initiative) Registry As Storage."
-    url = "https://github.com/deislabs/oras"
-
-    [[params.section1.tiles]]
     title = "Porter"
     icon = "porter"
     text = "Porter makes authoring CNAB bundles easier, handling your app and everything you need to deploy with it."


### PR DESCRIPTION
Because ORAS is now a CNCF sandbox project located in its own org (https://github.com/oras-project), I am thinking it does not make sense to continue to list it here; it's not ongoing as a deislabs effort.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>